### PR TITLE
Border when scaling

### DIFF
--- a/Mon2Cam.sh
+++ b/Mon2Cam.sh
@@ -3,7 +3,6 @@
 # Default Variables
 DEVICE_NUMBER=50
 FPS=60
-
 # End Default Variables
 
 # Options

--- a/Mon2Cam.sh
+++ b/Mon2Cam.sh
@@ -3,6 +3,7 @@
 # Default Variables
 DEVICE_NUMBER=50
 FPS=60
+
 # End Default Variables
 
 # Options
@@ -22,6 +23,7 @@ do
 			echo "-vf, --vertical-flip      vertically flip the monitor capture"
 			echo "-hf, --horizontal-flip    horizontally flip the monitor capture"
 			echo "-r, --resolution H:W      manually set output resolution"
+			echo "-b, --border              add border when scaling to avoid stretching"
 			exit
 		;;
 		-f | --framerate)
@@ -41,6 +43,9 @@ do
 		;;
 		-r | --resolution)
 			RES="-vf scale=$2"
+		;;
+		-b | --border)
+			BORDER=$true
 		;;
 	esac
 	shift
@@ -78,6 +83,15 @@ MONITOR_WIDTH=`echo $MONITOR_INFO | cut -f1 -d'/'`
 MONITOR_X=`echo $MONITOR_INFO | cut -f2 -d'+'`
 MONITOR_Y=`echo $MONITOR_INFO | cut -f3 -d'+'`
 # End Monitor information
+
+# Border
+if [ ! -z ${RES+x} ] && [ ! -z ${BORDER+x} ]
+then
+	RES_WIDTH=`echo ${RES} | cut -f2 -d'=' | cut -f1 -d':'`;
+	RES_HEIGHT=`echo ${RES} | cut -f2 -d':'`;
+	RES="${RES}:force_original_aspect_ratio=decrease,pad=$RES_WIDTH:$RES_HEIGHT:x=($RES_WIDTH-iw)/2:y=($RES_HEIGHT-ih)/2"
+fi
+# End of Border
 
 # Start Mon2Cam
 if ! $(sudo modprobe -r v4l2loopback &> /dev/null)


### PR DESCRIPTION
Added a way to use scaling without stretching by placing a border around the actual image.

In my testing this worked both with a 1650\*1080 and a 2560\*1080 display. I used it like this:

`./Mon2Cam.sh -m 0 -r 1920:1080 -b`

This means that the maximum resolution will be 1920\*1080 and ffmpeg will scale down the image and add borders around it. I also moves into the center, so it looks better. Using larger resolutions than 1920\*1080 should work (they work in ffplay) but I think the maximum allowed video resolution at least for free users in discord is 1920\*1080.

But it also works when using smaller resolutions like 1280\*720. The only thing that matters is that it has to be a 16:9 picture.