### PR TITLE
Support for recording from Wayland / wlroots-based compositors

### DIFF
--- a/Mon2Cam.sh
+++ b/Mon2Cam.sh
@@ -71,6 +71,14 @@ do
 	shift
 done
 
+# check for the `xisxwayland` tool and run it if it's found
+XISXWAYLAND=$(command -v xisxwayland)
+if [ -x "$XISXWAYLAND" ]
+then
+  # if X is actually Xwayland, then use wf-recorder instead
+  WAYLAND=$($XISXWAYLAND && echo true)
+fi
+
 # dependency checking for wayland recording, if enabled
 if [ "$WAYLAND" = true ]
 then

--- a/Mon2Cam.sh
+++ b/Mon2Cam.sh
@@ -198,41 +198,6 @@ do
     exit 1
   fi
 done
-=======
-  VIRTUAL_SINK="VirtualSink"
-  VIRTUAL_SINK_DESCRIPTION="Mon2Cam Sink"
-
-  # Create virtual sink if not already present
-  GREP_VIRTUAL_SINK=`pacmd list-sinks | grep "$VIRTUAL_SINK_DESCRIPTION"`
-  if [ -z "$GREP_VIRTUAL_SINK" ]
-  then
-    VIRTUAL_SINK_INDEX=`pactl load-module module-null-sink sink_name=$VIRTUAL_SINK`
-    echo "Created VirtualSink with index: $VIRTUAL_SINK_INDEX"
-    pacmd "update-sink-proplist "$VIRTUAL_SINK" device.description='$VIRTUAL_SINK_DESCRIPTION'"
-  fi
-
-  # Move selected playback onto virtual sink
-  SINK_INPUTS=`pacmd list-sink-inputs | tr '\n' '\r' | perl -pe 's/ *index: ([0-9]+).+?application\.name = "([^\r]+)"\r.+?(?=index:|$)/\2:\1\r/g' | tr '\r' '\n'` # Display indexes
-  echo "$SINK_INPUTS"
-
-  read -r -p "Select which windows to route:" ROUTED_SINKS
-  IFS=' ' read -ra ROUTED_SINKS_ARRAY <<< "$ROUTED_SINKS"
-  for sink in "${ROUTED_SINKS_ARRAY[@]}"
-  do
-    pacmd move-sink-input $sink "VirtualSink"
-  done
-
-  # Move selected microphone input to the virtual sink
-  SOURCES=`pacmd list-sources | tr '\n' '\r' | perl -pe 's/ *index: ([0-9]+).+?device\.description = "([^\r]+)"\r.+?(?=index:|$)/\2:\1\r/g' | tr '\r' '\n'` # Display indexes
-  echo "$SOURCES"
-
-  read -r -p "Select which sources to route:" ROUTED_SOURCES
-  IFS=' ' read -ra ROUTED_SOURCES_ARRAY <<< "$ROUTED_SOURCES"
-  for source in "${ROUTED_SOURCES_ARRAY[@]}"
-  do
-    pactl load-module module-loopback source=$source sink="$VIRTUAL_SINK">/dev/null
-  done
->>>>>>> ffb9dba... Remove dependency check for wlr-randr and fix broken conditional.
 fi
 
 echo "CTRL + C to stop"

--- a/Mon2Cam.sh
+++ b/Mon2Cam.sh
@@ -16,67 +16,67 @@ WAYLAND=false
 # Options
 while [ ! $# -eq 0 ]
 do
-	case "$1" in
-		-h | --help)
-			echo "$0 - Monitor to Camera"
-			echo ""
-			echo "$0 [options] [value]"
-			echo ""
-			echo "options:"
-			echo "-h,  --help               show help"
-			echo "-f,  --framerate FPS      set framerate"
-			echo "-d,  --device-number NUM  set device number"
-			echo "-m,  --monitor-id NUM     set monitor id"
-			echo "-r,  --resolution W:H     manually set output resolution"
-			echo "-vf, --vertical-flip      vertically flip the monitor capture"
-			echo "-hf, --horizontal-flip    horizontally flip the monitor capture"
-			echo "-b,  --border             add border when scaling to avoid stretching"
-			echo "-s,  --sound              create virtual sink and route sound into it (requires pulseaudio)"
-			echo "-v,  --verbose            Show verbose output"
-      echo "-w,  --wayland            enable support for Wayland sessions using wf-recorder"
-			exit
-		;;
-		-f | --framerate)
-			FPS=$2
-		;;
-		-d | --device-number)
-			DEVICE_NUMBER=$2
-		;;
-		-m | --monitor-id)
-			MONITOR_ID=$2
-		;;
-		-r | --resolution)
-			FFMPEG_OPTIONS+="-vf scale=$2"
-			RESOLUTION=$2
-		;;
-		-vf | --vertical-flip)
-			FFMPEG_OPTIONS+="-vf vflip"
-		;;
-		-hf | --horizontal-flip)
-			FFMPEG_OPTIONS+="-vf hflip"
-		;;
-		-b | --border)
-			BORDER=true
-		;;
-		-s | --sound)
-			SOUND=true
-		;;
-		-v | --verbose)
-						OUTPUT=/dev/tty
-				;;
-		-w | --wayland)
-			WAYLAND=true
-		;;
-	esac
-	shift
+  case "$1" in
+    -h | --help)
+      echo "$0 - Monitor to Camera"
+      echo ""
+      echo "$0 [options] [value]"
+      echo ""
+      echo "options:"
+      echo "-h, --help               show help"
+      echo "-f, --framerate FPS     set framerate"
+      echo "-d, --device-number NUM set device number"
+      echo "-m, --monitor-id NUM     set monitor id"
+      echo "-r, --resolution W:H     manually set output resolution"
+      echo "-vf, --vertical-flip      vertically flip the monitor capture"
+      echo "-hf, --horizontal-flip    horizontally flip the monitor capture"
+      echo "-b, --border             add border when scaling to avoid stretching"
+      echo "-s, --sound             create virtual sink and route sound into it (requires pulseaudio)"
+      echo "-v, --verbose           Show verbose output"
+      echo "-w, --wayland           enable support for Wayland sessions using wf-recorder"
+      exit
+    ;;
+    -f | --framerate)
+      FPS=$2
+    ;;
+    -d | --device-number)
+      DEVICE_NUMBER=$2
+    ;;
+    -m | --monitor-id)
+      MONITOR_ID=$2
+    ;;
+    -r | --resolution)
+      FFMPEG_OPTIONS+="-vf scale=$2"
+      RESOLUTION=$2
+    ;;
+    -vf | --vertical-flip)
+      FFMPEG_OPTIONS+="-vf vflip"
+    ;;
+    -hf | --horizontal-flip)
+      FFMPEG_OPTIONS+="-vf hflip"
+    ;;
+    -b | --border)
+      BORDER=true
+    ;;
+    -s | --sound)
+      SOUND=true
+    ;;
+    -v | --verbose)
+            OUTPUT=/dev/tty
+        ;;
+    -w | --wayland)
+      WAYLAND=true
+    ;;
+  esac
+  shift
 done
 
 # check for the `xisxwayland` tool and run it if it's found
 XISXWAYLAND=$(command -v xisxwayland)
 if [ -x "$XISXWAYLAND" ]
 then
-	# if X is actually Xwayland, then use wf-recorder instead
-	WAYLAND=$($XISXWAYLAND && echo true)
+  # if X is actually Xwayland, then use wf-recorder instead
+  WAYLAND=$($XISXWAYLAND && echo true)
 elif [ -v WAYLAND_DISPLAY ]
 then
   # alternative check, if WAYLAND_DISPLAY is set then enable support
@@ -86,93 +86,87 @@ fi
 # dependency checking for wayland recording, if enabled
 if [ "$WAYLAND" = true ]
 then
-	WFRECORDER=$(command -v wf-recorder)
-	if ! [ -x "$WFRECORDER" ]
-	then
-		echo "Error: wf-recorder is not installed."
-		exit 1
-	fi
-	WLRRANDR=$(command -v wlr-randr)
-	if ! [ -x "$WLRRANDR" ]
-	then
-		echo "Error: wlr-randr is not installed."
-		exit 1
-	fi
+  WFRECORDER=$(command -v wf-recorder)
+  if ! [ -x "$WFRECORDER" ]
+  then
+    echo "Error: wf-recorder is not installed."
+    exit 1
+  fi
 else
-	# only X sessions will need xrandr
-	XRANDR=$(command -v xrandr)
-	if ! [ -x "$XRANDR" ]
-	then
-		echo "Error: xrandr is not installed."
-		exit 1
-	fi
+  # only X sessions will need xrandr
+  XRANDR=$(command -v xrandr)
+  if ! [ -x "$XRANDR" ]
+  then
+    echo "Error: xrandr is not installed."
+    exit 1
+  fi
 fi
 
 FFMPEG=$(command -v ffmpeg)
 if ! [ -x "$FFMPEG" ]
 then
-	echo "Error: ffmpeg is not installed."
-	exit 1
+  echo "Error: ffmpeg is not installed."
+  exit 1
 fi
 
 # Reload v4l2loopback if device doesn't exist
 if [ ! -c /dev/video"$DEVICE_NUMBER" ]
 then
-	# Unload v4l2loopback module
-	if ! $(sudo modprobe -r v4l2loopback &> /dev/null)
-	then
-		echo "Unable to unload v4l2loopback, make sure you installed v4l2loopback and close any programs using virtual video devices and try again."
-		exit 1
-	fi
+  # Unload v4l2loopback module
+  if ! $(sudo modprobe -r v4l2loopback &> /dev/null)
+  then
+    echo "Unable to unload v4l2loopback, make sure you installed v4l2loopback and close any programs using virtual video devices and try again."
+    exit 1
+  fi
 
-	# Load v4l2loopback module
-	sudo modprobe v4l2loopback video_nr="$DEVICE_NUMBER" 'card_label=Mon2Cam'
+  # Load v4l2loopback module
+  sudo modprobe v4l2loopback video_nr="$DEVICE_NUMBER" 'card_label=Mon2Cam'
 fi
 
 # Option checking
 if [ "$BORDER" = true ]
 then
-	if [ -z "$RESOLUTION" ]
-	then
-		echo "You didn't specify a resolution (-r 1920:1080)"
-		exit 1
-	fi
+  if [ -z "$RESOLUTION" ]
+  then
+    echo "You didn't specify a resolution (-r 1920:1080)"
+    exit 1
+  fi
 
-	RES_WIDTH=$(echo "${RESOLUTION}" | cut -f2 -d'=' | cut -f1 -d':');
-	RES_HEIGHT=$(echo "${RESOLUTION}" | cut -f2 -d':');
-	RESOLUTION="${RESOLUTION}:force_original_aspect_ratio=decrease,pad=$RES_WIDTH:$RES_HEIGHT:x=($RES_WIDTH-iw)/2:y=($RES_HEIGHT-ih)/2"
+  RES_WIDTH=$(echo "${RESOLUTION}" | cut -f2 -d'=' | cut -f1 -d':');
+  RES_HEIGHT=$(echo "${RESOLUTION}" | cut -f2 -d':');
+  RESOLUTION="${RESOLUTION}:force_original_aspect_ratio=decrease,pad=$RES_WIDTH:$RES_HEIGHT:x=($RES_WIDTH-iw)/2:y=($RES_HEIGHT-ih)/2"
 fi
 
 # Pick monitor
 # if recording a Wayland session, wf-recorder can prompt the user itself
-if [ [ "$WAYLAND" = false ] -a [ -z "$MONITOR_ID" ] ]
+if [ "$WAYLAND" = false ] -a [ -z "$MONITOR_ID" ]
 then
   $XRANDR --listactivemonitors
-	read -r -p "Which monitor: " MONITOR_ID
+  read -r -p "Which monitor: " MONITOR_ID
 fi
 
 # AUDIO
 if [ "$SOUND" = true ]
 then
-	VIRTUAL_SINK="VirtualSink"
-	VIRTUAL_SINK_DESCRIPTION="Mon2Cam Sink"
+  VIRTUAL_SINK="VirtualSink"
+  VIRTUAL_SINK_DESCRIPTION="Mon2Cam Sink"
 
-	# Create virtual sink if not already present
-	GREP_VIRTUAL_SINK=`pacmd list-sinks | grep "$VIRTUAL_SINK_DESCRIPTION"`
-	if [ -z "$GREP_VIRTUAL_SINK" ]
-	then
-		VIRTUAL_SINK_INDEX=`pactl load-module module-null-sink sink_name=$VIRTUAL_SINK`
-		echo "Created VirtualSink with index: $VIRTUAL_SINK_INDEX"
-		pacmd "update-sink-proplist "$VIRTUAL_SINK" device.description='$VIRTUAL_SINK_DESCRIPTION'"
-		pacmd "update-source-proplist VirtualSink.monitor device.description=\"Monitor of Mon2Cam Sink\"" # The double-escaped quotes are not a mistake: https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/issues/615
-	else
-		echo "Found a VirtualSink re-using it."
-	fi
-	# Move selected playback onto virtual sink
-	SINK_INPUTS=`pacmd list-sink-inputs | tr '\n' '\r' | perl -pe 's/ *index: ([0-9]+).+?application\.name = "([^\r]+)"\r.+?(?=index:|$)/\2:\1\r/g' | tr '\r' '\n'` # Display indexes
-	echo "$SINK_INPUTS"
+  # Create virtual sink if not already present
+  GREP_VIRTUAL_SINK=`pacmd list-sinks | grep "$VIRTUAL_SINK_DESCRIPTION"`
+  if [ -z "$GREP_VIRTUAL_SINK" ]
+  then
+    VIRTUAL_SINK_INDEX=`pactl load-module module-null-sink sink_name=$VIRTUAL_SINK`
+    echo "Created VirtualSink with index: $VIRTUAL_SINK_INDEX"
+    pacmd "update-sink-proplist "$VIRTUAL_SINK" device.description='$VIRTUAL_SINK_DESCRIPTION'"
+    pacmd "update-source-proplist VirtualSink.monitor device.description=\"Monitor of Mon2Cam Sink\"" # The double-escaped quotes are not a mistake: https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/issues/615
+  else
+    echo "Found a VirtualSink re-using it."
+  fi
+  # Move selected playback onto virtual sink
+  SINK_INPUTS=`pacmd list-sink-inputs | tr '\n' '\r' | perl -pe 's/ *index: ([0-9]+).+?application\.name = "([^\r]+)"\r.+?(?=index:|$)/\2:\1\r/g' | tr '\r' '\n'` # Display indexes
+  echo "$SINK_INPUTS"
 
-	read -r -p "Select which window(s) to route (Space separated list e.g.:3 5):" ROUTED_SINKS
+  read -r -p "Select which window(s) to route (Space separated list e.g.:3 5):" ROUTED_SINKS
 IFS=' ' read -ra ROUTED_SINKS_ARRAY <<< "$ROUTED_SINKS"
 for sink in "${ROUTED_SINKS_ARRAY[@]}"
 do
@@ -197,6 +191,41 @@ do
     exit 1
   fi
 done
+=======
+  VIRTUAL_SINK="VirtualSink"
+  VIRTUAL_SINK_DESCRIPTION="Mon2Cam Sink"
+
+  # Create virtual sink if not already present
+  GREP_VIRTUAL_SINK=`pacmd list-sinks | grep "$VIRTUAL_SINK_DESCRIPTION"`
+  if [ -z "$GREP_VIRTUAL_SINK" ]
+  then
+    VIRTUAL_SINK_INDEX=`pactl load-module module-null-sink sink_name=$VIRTUAL_SINK`
+    echo "Created VirtualSink with index: $VIRTUAL_SINK_INDEX"
+    pacmd "update-sink-proplist "$VIRTUAL_SINK" device.description='$VIRTUAL_SINK_DESCRIPTION'"
+  fi
+
+  # Move selected playback onto virtual sink
+  SINK_INPUTS=`pacmd list-sink-inputs | tr '\n' '\r' | perl -pe 's/ *index: ([0-9]+).+?application\.name = "([^\r]+)"\r.+?(?=index:|$)/\2:\1\r/g' | tr '\r' '\n'` # Display indexes
+  echo "$SINK_INPUTS"
+
+  read -r -p "Select which windows to route:" ROUTED_SINKS
+  IFS=' ' read -ra ROUTED_SINKS_ARRAY <<< "$ROUTED_SINKS"
+  for sink in "${ROUTED_SINKS_ARRAY[@]}"
+  do
+    pacmd move-sink-input $sink "VirtualSink"
+  done
+
+  # Move selected microphone input to the virtual sink
+  SOURCES=`pacmd list-sources | tr '\n' '\r' | perl -pe 's/ *index: ([0-9]+).+?device\.description = "([^\r]+)"\r.+?(?=index:|$)/\2:\1\r/g' | tr '\r' '\n'` # Display indexes
+  echo "$SOURCES"
+
+  read -r -p "Select which sources to route:" ROUTED_SOURCES
+  IFS=' ' read -ra ROUTED_SOURCES_ARRAY <<< "$ROUTED_SOURCES"
+  for source in "${ROUTED_SOURCES_ARRAY[@]}"
+  do
+    pactl load-module module-loopback source=$source sink="$VIRTUAL_SINK">/dev/null
+  done
+>>>>>>> ffb9dba... Remove dependency check for wlr-randr and fix broken conditional.
 fi
 
 echo "CTRL + C to stop"
@@ -222,6 +251,6 @@ then
 		-f v4l2 \
 		/dev/video"$DEVICE_NUMBER" &> $OUTPUT
 else
-	# with wf-recorder, it is not necessary to know the resolution and position
-	$WFRECORDER -x yuv420p -c rawvideo -m v4l2 -f /dev/video"$DEVICE_NUMBER" &>/dev/null
+  # with wf-recorder, it is not necessary to know the resolution and position
+  $WFRECORDER -x yuv420p -c rawvideo -m v4l2 -f /dev/video"$DEVICE_NUMBER" &>/dev/null
 fi

--- a/Mon2Cam.sh
+++ b/Mon2Cam.sh
@@ -12,63 +12,64 @@ BORDER=false
 SOUND=false
 OUTPUT=/dev/null
 WAYLAND=false
+FORCE_X11=false
 
 # Options
 while [ ! $# -eq 0 ]
 do
-  case "$1" in
-    -h | --help)
-      echo "$0 - Monitor to Camera"
-      echo ""
-      echo "$0 [options] [value]"
-      echo ""
-      echo "options:"
-      echo "-h, --help               show help"
-      echo "-f, --framerate FPS     set framerate"
-      echo "-d, --device-number NUM set device number"
-      echo "-m, --monitor-id NUM     set monitor id"
-      echo "-r, --resolution W:H     manually set output resolution"
-      echo "-vf, --vertical-flip      vertically flip the monitor capture"
-      echo "-hf, --horizontal-flip    horizontally flip the monitor capture"
-      echo "-b, --border             add border when scaling to avoid stretching"
-      echo "-s, --sound             create virtual sink and route sound into it (requires pulseaudio)"
-      echo "-v, --verbose           Show verbose output"
-      echo "-w, --wayland           enable support for Wayland sessions using wf-recorder"
-      exit
-    ;;
-    -f | --framerate)
-      FPS=$2
-    ;;
-    -d | --device-number)
-      DEVICE_NUMBER=$2
-    ;;
-    -m | --monitor-id)
-      MONITOR_ID=$2
-    ;;
-    -r | --resolution)
-      FFMPEG_OPTIONS+="-vf scale=$2"
-      RESOLUTION=$2
-    ;;
-    -vf | --vertical-flip)
-      FFMPEG_OPTIONS+="-vf vflip"
-    ;;
-    -hf | --horizontal-flip)
-      FFMPEG_OPTIONS+="-vf hflip"
-    ;;
-    -b | --border)
-      BORDER=true
-    ;;
-    -s | --sound)
-      SOUND=true
-    ;;
-    -v | --verbose)
-            OUTPUT=/dev/tty
-        ;;
-    -w | --wayland)
-      WAYLAND=true
-    ;;
-  esac
-  shift
+	case "$1" in
+		-h | --help)
+			echo "$0 - Monitor to Camera"
+			echo ""
+			echo "$0 [options] [value]"
+			echo ""
+			echo "options:"
+			echo "-h,  --help               show help"
+			echo "-f,  --framerate FPS      set framerate"
+			echo "-d,  --device-number NUM  set device number"
+			echo "-m,  --monitor-id NUM     set monitor id"
+			echo "-r,  --resolution W:H     manually set output resolution"
+			echo "-vf, --vertical-flip      vertically flip the monitor capture"
+			echo "-hf, --horizontal-flip    horizontally flip the monitor capture"
+			echo "-b,  --border             add border when scaling to avoid stretching"
+			echo "-s,  --sound              create virtual sink and route sound into it (requires pulseaudio)"
+			echo "-v,  --verbose            Show verbose output"
+      echo "-w,  --wayland            enable support for Wayland sessions using wf-recorder"
+			exit
+		;;
+		-f | --framerate)
+			FPS=$2
+		;;
+		-d | --device-number)
+			DEVICE_NUMBER=$2
+		;;
+		-m | --monitor-id)
+			MONITOR_ID=$2
+		;;
+		-r | --resolution)
+			FFMPEG_OPTIONS+="-vf scale=$2"
+			RESOLUTION=$2
+		;;
+		-vf | --vertical-flip)
+			FFMPEG_OPTIONS+="-vf vflip"
+		;;
+		-hf | --horizontal-flip)
+			FFMPEG_OPTIONS+="-vf hflip"
+		;;
+		-b | --border)
+			BORDER=true
+		;;
+		-s | --sound)
+			SOUND=true
+		;;
+		-v | --verbose)
+						OUTPUT=/dev/tty
+				;;
+		-w | --wayland)
+			WAYLAND=true
+		;;
+	esac
+	shift
 done
 
 # check for the `xisxwayland` tool and run it if it's found
@@ -81,6 +82,12 @@ elif [ -v WAYLAND_DISPLAY ]
 then
   # alternative check, if WAYLAND_DISPLAY is set then enable support
   WAYLAND=true
+fi
+
+# the flag to force x11 support disables wayland support
+if [ "$FORCE_X11" = true ]
+then
+  WAYLAND=false
 fi
 
 # dependency checking for wayland recording, if enabled
@@ -253,7 +260,14 @@ then
 else
   # with wf-recorder, it is not necessary to know the resolution and position
   # stdout must still go to screen to prompt user output selection
-  $WFRECORDER -x yuv420p \
+  if [ -n "$MONITOR_ID" ] # use pre-existing monitor selection is provided
+  then
+    WF_OUTPUT="-o $MONITOR_ID"
+  else
+    WF_OUTPUT=""
+  fi
+  $WFRECORDER $WF_OUTPUT \
+    -x yuv420p \
     -c rawvideo \
     -m v4l2 \
     -f /dev/video"$DEVICE_NUMBER"

--- a/Mon2Cam.sh
+++ b/Mon2Cam.sh
@@ -77,6 +77,10 @@ if [ -x "$XISXWAYLAND" ]
 then
 	# if X is actually Xwayland, then use wf-recorder instead
 	WAYLAND=$($XISXWAYLAND && echo true)
+elif [ -v WAYLAND_DISPLAY ]
+then
+  # alternative check, if WAYLAND_DISPLAY is set then enable support
+  WAYLAND=true
 fi
 
 # dependency checking for wayland recording, if enabled
@@ -110,7 +114,6 @@ then
 	echo "Error: ffmpeg is not installed."
 	exit 1
 fi
-
 
 # Reload v4l2loopback if device doesn't exist
 if [ ! -c /dev/video"$DEVICE_NUMBER" ]
@@ -203,9 +206,9 @@ do
 done
 fi
 
-	# Use x11grab to stream screen into v4l2loopback device
-	echo "CTRL + C to stop"
-	echo "Your screen will look mirrored for you, not others"
+# Use x11grab to stream screen into v4l2loopback device
+echo "CTRL + C to stop"
+echo "Your screen will look mirrored for you, not others"
 
 if ! [ "$WAYLAND" = true ]
 then

--- a/Mon2Cam.sh
+++ b/Mon2Cam.sh
@@ -62,11 +62,11 @@ do
 			SOUND=true
 		;;
 		-v | --verbose)
-            OUTPUT=/dev/tty
-        ;;
-    -w | --wayland)
-      WAYLAND=true
-    ;;
+						OUTPUT=/dev/tty
+				;;
+		-w | --wayland)
+			WAYLAND=true
+		;;
 	esac
 	shift
 done
@@ -75,33 +75,33 @@ done
 XISXWAYLAND=$(command -v xisxwayland)
 if [ -x "$XISXWAYLAND" ]
 then
-  # if X is actually Xwayland, then use wf-recorder instead
-  WAYLAND=$($XISXWAYLAND && echo true)
+	# if X is actually Xwayland, then use wf-recorder instead
+	WAYLAND=$($XISXWAYLAND && echo true)
 fi
 
 # dependency checking for wayland recording, if enabled
 if [ "$WAYLAND" = true ]
 then
-  WFRECORDER=$(command -v wf-recorder)
-  if ! [ -x "$WFRECORDER" ]
-  then
-    echo "Error: wf-recorder is not installed."
-    exit 1
-  fi
-  WLRRANDR=$(command -v wlr-randr)
-  if ! [ -x "$WLRRANDR" ]
-  then
-    echo "Error: wlr-randr is not installed."
-    exit 1
-  fi
+	WFRECORDER=$(command -v wf-recorder)
+	if ! [ -x "$WFRECORDER" ]
+	then
+		echo "Error: wf-recorder is not installed."
+		exit 1
+	fi
+	WLRRANDR=$(command -v wlr-randr)
+	if ! [ -x "$WLRRANDR" ]
+	then
+		echo "Error: wlr-randr is not installed."
+		exit 1
+	fi
 else
-  # only X sessions will need xrandr
-  XRANDR=$(command -v xrandr)
-  if ! [ -x "$XRANDR" ]
-  then
-    echo "Error: xrandr is not installed."
-    exit 1
-  fi
+	# only X sessions will need xrandr
+	XRANDR=$(command -v xrandr)
+	if ! [ -x "$XRANDR" ]
+	then
+		echo "Error: xrandr is not installed."
+		exit 1
+	fi
 fi
 
 FFMPEG=$(command -v ffmpeg)
@@ -143,15 +143,15 @@ fi
 # Pick monitor
 if [ -z "$MONITOR_ID" ]
 then
-  if [ "$WAYLAND" = true ]
-  then
-    # swaymsg would be more ideal but is specific to sway
-    # parsing the output of wlr-randr works but is not ideal
-    # this will show the current display resolution, position, ID, and name
-    $WLRRANDR | egrep '(current|Position|")' 
-  else
-    $XRANDR --listactivemonitors
-  fi
+	if [ "$WAYLAND" = true ]
+	then
+		# swaymsg would be more ideal but is specific to sway
+		# parsing the output of wlr-randr works but is not ideal
+		# this will show the current display resolution, position, ID, and name
+		$WLRRANDR | egrep '(current|Position|")'
+	else
+		$XRANDR --listactivemonitors
+	fi
 	read -r -p "Which monitor: " MONITOR_ID
 fi
 
@@ -203,29 +203,29 @@ do
 done
 fi
 
-  # Use x11grab to stream screen into v4l2loopback device
-  echo "CTRL + C to stop"
-  echo "Your screen will look mirrored for you, not others"
-  
+	# Use x11grab to stream screen into v4l2loopback device
+	echo "CTRL + C to stop"
+	echo "Your screen will look mirrored for you, not others"
+
 if ! [ "$WAYLAND" = true ]
 then
-  # Monitor information
-  MONITOR_INFO=$(xrandr --listactivemonitors | grep "$MONITOR_ID:" | cut -f4 -d' ')
-  MONITOR_HEIGHT=$(echo "$MONITOR_INFO" | cut -f2 -d'/' | cut -f2 -d'x')
-  MONITOR_WIDTH=$(echo "$MONITOR_INFO" | cut -f1 -d'/')
-  MONITOR_X=$(echo "$MONITOR_INFO" | cut -f2 -d'+')
-  MONITOR_Y=$(echo "$MONITOR_INFO" | cut -f3 -d'+')
+	# Monitor information
+	MONITOR_INFO=$(xrandr --listactivemonitors | grep "$MONITOR_ID:" | cut -f4 -d' ')
+	MONITOR_HEIGHT=$(echo "$MONITOR_INFO" | cut -f2 -d'/' | cut -f2 -d'x')
+	MONITOR_WIDTH=$(echo "$MONITOR_INFO" | cut -f1 -d'/')
+	MONITOR_X=$(echo "$MONITOR_INFO" | cut -f2 -d'+')
+	MONITOR_Y=$(echo "$MONITOR_INFO" | cut -f3 -d'+')
 
-  $FFMPEG \
-    -f x11grab \
-    -r "$FPS" \
-    -s "$MONITOR_WIDTH"x"$MONITOR_HEIGHT" \
-    -i "$DISPLAY"+"$MONITOR_X","$MONITOR_Y" \
-    $FFMPEG_OPTIONS \
-    -pix_fmt yuv420p \
-    -f v4l2 \
-    /dev/video"$DEVICE_NUMBER" &> $OUTPUT
+	$FFMPEG \
+		-f x11grab \
+		-r "$FPS" \
+		-s "$MONITOR_WIDTH"x"$MONITOR_HEIGHT" \
+		-i "$DISPLAY"+"$MONITOR_X","$MONITOR_Y" \
+		$FFMPEG_OPTIONS \
+		-pix_fmt yuv420p \
+		-f v4l2 \
+		/dev/video"$DEVICE_NUMBER" &> $OUTPUT
 else
-  # with wf-recorder, it is not necessary to know the resolution and position
-  $WFRECORDER -o $MONITOR_ID -x yuv420p -c rawvideo -m v4l2 -f /dev/video"$DEVICE_NUMBER" &>/dev/null 
+	# with wf-recorder, it is not necessary to know the resolution and position
+	$WFRECORDER -o $MONITOR_ID -x yuv420p -c rawvideo -m v4l2 -f /dev/video"$DEVICE_NUMBER" &>/dev/null
 fi

--- a/Mon2Cam.sh
+++ b/Mon2Cam.sh
@@ -139,7 +139,7 @@ fi
 
 # Pick monitor
 # if recording a Wayland session, wf-recorder can prompt the user itself
-if [ "$WAYLAND" = false ] -a [ -z "$MONITOR_ID" ]
+if [ "$WAYLAND" = false ] && [ -z "$MONITOR_ID" ]
 then
   $XRANDR --listactivemonitors
   read -r -p "Which monitor: " MONITOR_ID
@@ -252,5 +252,9 @@ then
 		/dev/video"$DEVICE_NUMBER" &> $OUTPUT
 else
   # with wf-recorder, it is not necessary to know the resolution and position
-  $WFRECORDER -x yuv420p -c rawvideo -m v4l2 -f /dev/video"$DEVICE_NUMBER" &>/dev/null
+  # stdout must still go to screen to prompt user output selection
+  $WFRECORDER -x yuv420p \
+    -c rawvideo \
+    -m v4l2 \
+    -f /dev/video"$DEVICE_NUMBER"
 fi

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Fix for multi-monitor Discord screensharing
 
 Dependencies:
 -
+- wf-recorder (for Wayland support)
 - xrandr
 - ffmpeg
 - v4l2loopback 0.12+
@@ -36,6 +37,8 @@ options:
 -r,  --resolution W:H     manually set output resolution
 -b,  --border             add border when scaling to avoid stretching
 -s,  --sound              create virtual sink and route sound into it (requires pulseaudio)
+-w,  --wayland            force support for Wayland sessions
+-x,  --x11                force support for X11 sessions
 ```
 
 ```


### PR DESCRIPTION
I recently switched from using i3 as my window manager to using [sway](https://github.com/swaywm/sway) so a lot of things that depended on various parts of X stopped working. The Xwayland compatibility layer only records a black screen if used to capture the display, but when I saw [wf-recorder](https://github.com/ammen99/wf-recorder) in the Fedora repositories I realized that it would be possible to add support for Wayland sessions to this script.

Currently, the script checks for the presence of the `xisxwayland` utility and if found, runs it to determine whether or not to use X or Wayland recording. I was uncertain about how common this utility is on systems which do not have Wayland stuff installed; on Fedora it is part of the `xorg-x11-server-utils` package which includes `xrandr` and other very common X utilities but I am not sure this is true for other distributions. 

The prompt to select the output uses [wlr-randr](https://github.com/emersion/wlr-randr), just to let the user select the output they want to stream in a similar fashion to how `xrandr` is used. The identifiers are no longer integers but strings like "DP-2" or "HDMI-A-1", so I changed the variable name to reflect this, though nothing changed in how it is used in the existing code. 

I was not able to add equivalent features for a couple things, like forcing a framerate, border/specific resolution, and vertical/horizontal flipping. This is mostly because currently wf-recorder doesn't allow attempting to capture a set number of frames per second, and it also doesn't allow adding arbitrary options to be passed to ffmpeg, like video filters. There's already [at least one](https://github.com/ammen99/wf-recorder/issues/96) issue open requesting one of these features, and it seems to be under active development, so these may be implemented soon and I can then use those features in this script.

![mpv-shot0003](https://user-images.githubusercontent.com/358724/88477552-841b8f80-cf30-11ea-8125-60fabb198a39.jpg)

