### PR TITLE
fix: Make Markdown links reference correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Fix for multi-monitor Discord screensharing
 ## Dependencies:
 
 - [Deno]
-- [xrandr](X11)
-- [ffmpeg](X11) or [wf-recorder](wlroots)
+- [xrandr] (X11)
+- [ffmpeg] (X11) or [wf-recorder](wlroots)
 - [v4l2loopback] 0.12+
 
 Note:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Fix for multi-monitor Discord screensharing
 
 - [Deno]
 - [xrandr] (X11)
-- [ffmpeg] (X11) or [wf-recorder](wlroots)
+- [ffmpeg] (X11) or [wf-recorder] (wlroots)
 - [v4l2loopback] 0.12+
 
 Note:


### PR DESCRIPTION
A parenthesis beside `[link-text]()` will always overwrite `[link-text]: <actual link reference>` elsewhere in document here on Github flavored Markdown.