### PR TITLE
Fixed typo in the new hwenc feature's help message.

### DIFF
--- a/src/libraries/options.ts
+++ b/src/libraries/options.ts
@@ -54,7 +54,7 @@ export default class Options {
 					"-w   --wayland     Force the use of the wayland backend",
 					"-x   --x11         Force the use of the X11 backend",
 					"-v,  --verbose,    Show verbose output",
-					"-e, --hwenc,      Use hardware encoding. You can get a list of supported encoders using \"ffmpec -hwaccels\"",
+					"-e, --hwenc,      Use hardware encoding. You can get a list of supported encoders using \"ffmpeg -hwaccels\"",
 					"",
 					"Flags with * do not work with wayland",
 					"Wayland support is only for wlroots compositors",


### PR DESCRIPTION
Hello, I noticed there was a typo in the `--hwenc` feature's help message, so I fixed it!