### PR TITLE
Detect if pipewire is present

### DIFF
--- a/src/backends/audio.ts
+++ b/src/backends/audio.ts
@@ -25,6 +25,12 @@ let createdModules: Number[] = [];
 export default async function (options: Options, logger: Logger) {
 	// TODO: Detect already created modules
 
+	// Detect if pipewire is currently active
+	let sinks = await getSinks();
+	if(sinks.length > 0 && sinks[0].module == "PipeWire") {
+		logger.panic("PipeWire not supported.");
+	}
+
 	let apps = await getUserSelectedApplications();
 	let sources = await getUserSelectedSources();
 
@@ -78,9 +84,10 @@ export default async function (options: Options, logger: Logger) {
 				});
 				resolve(sinks);
 			}
-
-			logger.panic(`An error occured while trying to list the sinks`, cmd.status.code);
-			reject();
+			else {
+				logger.panic(`An error occured while trying to list the sinks`, cmd.status.code);
+				reject();
+			}
 		});
 	}
 

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -41,6 +41,16 @@ if (!options.wayland) {
 		.catch(() => null);
 }
 
+if (options.sound) {
+	await exec("pipewire --version", { output: 3 })
+		.then((cmd) => {
+			if (cmd.status.success) {
+				logger.warn("PipeWire is not currently supported. You can use catia to do the routing yourself.");
+			}
+		})
+		.catch(() => null);
+}
+
 if (options.sound) await startSound(options, logger);
 if (options.wayland) {
 	logger.info("Wayland detected, to use X11 add -x");


### PR DESCRIPTION
I added 2 checks, since I didn't want to panic on a system which has pipewire installed, but isn't active. (I'm not really sure who would do this, but still)

I don't have a system which has pure pulseaudio installed, so I couldn't test it on pa. Could you test it @ShayBox?