### PR TITLE
use deno 1.16 signal listener api

### DIFF
--- a/src/mod.ts
+++ b/src/mod.ts
@@ -51,8 +51,8 @@ if (options.wayland) {
 	startX11(options, logger);
 }
 
-for await (const _ of Deno.signal("SIGINT")) {
+Deno.addSignalListener("SIGINT", async () => {
 	await disposeAudio(logger);
 	logger.write();
 	Deno.exit();
-}
+});


### PR DESCRIPTION
as per the [deno 1.16 release notes](https://deno.com/blog/v1.16#new-unstable-signal-listener-api), the old signal listener API is superseded by this new API, and such the code breaks on 1.16. this pr updates the code to use the new API